### PR TITLE
TextFormField compatible constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Keep original value of the text field and consider its value valid when it has not changed.
+
 ## 2.0.1+3
 
 * TextFormField compatible constructor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,27 @@
+## 2.0.3
+
+Call `onChange` after validation and after restoring original value.
+
 ## 2.0.2
 
-* Keep original value of the text field and consider its value valid when it has not changed.
+Keep original value of the text field and consider its value valid when it has not changed.
 
 ## 2.0.1+3
 
-* TextFormField compatible constructor
+TextFormField compatible constructor
 
 ## 2.0.0+3
 
-* Null safety
+Null safety
 
 ## 1.0.0+2
 
-* Adding GIF to README.md
+Adding GIF to README.md
 
 ## 1.0.0+1
 
-* Adding details to README.md
+Adding details to README.md
 
 ## 1.0.0
 
-* Initial release.
+Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1+3
+
+* TextFormField compatible constructor
+
 ## 2.0.0+3
 
 * Null safety

--- a/async_textformfield.iml
+++ b/async_textformfield.iml
@@ -15,8 +15,8 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 29 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Flutter Plugins" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.0'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,8 +29,8 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   final TextEditingController controller = TextEditingController();
 
-  Future<bool> isValidPasscode(String value) async {
-    return await Future.delayed(Duration(seconds: 2), () => value.isNotEmpty && value.toLowerCase() == 'batman');
+  Future<String?> isValidPasscode(String value) async {
+    return await Future.delayed(Duration(seconds: 2), () => value.isNotEmpty && value.toLowerCase() == 'batman' ? null : 'wrong password');
   }
 
   @override
@@ -43,17 +43,15 @@ class _MyHomePageState extends State<MyHomePage> {
         padding: const EdgeInsets.all(10.0),
         child: Center(
           child: Form(
-              child: Center(
-            child: AsyncTextFormField(
-              controller: controller,
-              validationDebounce: Duration(milliseconds: 500),
-              validator: isValidPasscode,
-              hintText: 'Enter the Passcode',
-              isValidatingMessage: 'Comparing with the hash from a secure server..',
-              valueIsInvalidMessage: 'Nope, Try harder..',
-              valueIsEmptyMessage: 'No one sets an empty passcode!',
+            child: Center(
+              child: AsyncTextFormField(
+                controller: controller,
+                validationDebounce: Duration(milliseconds: 500),
+                validator: isValidPasscode,
+                decoration: InputDecoration(hintText: 'Enter the Passcode'),
+              ),
             ),
-          )),
+          ),
         ),
       ),
     );

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.0.0+1
+version: 2.0.1+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -29,7 +29,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the Cupertino Icons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/lib/async_textformfield.dart
+++ b/lib/async_textformfield.dart
@@ -117,6 +117,13 @@ class _AsyncTextFormFieldState extends State<AsyncTextFormField> {
   bool isValid = false;
   bool isDirty = false;
   bool isWaiting = false;
+  late String originalValue;
+
+  @override
+  void initState() {
+    originalValue = widget.initialValue ?? widget.controller?.text ?? '';
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -132,6 +139,16 @@ class _AsyncTextFormFieldState extends State<AsyncTextFormField> {
             isValid = msg == null;
             isValidating = false;
             validationMessage = msg;
+          });
+          cancelTimer();
+          return;
+        }
+        if (text == originalValue) {
+          // edited text is same as the original one, the value is valid, no need to validate it
+          setState(() {
+            isValid = true;
+            isValidating = false;
+            validationMessage = null;
           });
           cancelTimer();
           return;

--- a/lib/async_textformfield.dart
+++ b/lib/async_textformfield.dart
@@ -140,6 +140,7 @@ class _AsyncTextFormFieldState extends State<AsyncTextFormField> {
             isValidating = false;
             validationMessage = msg;
           });
+          widget.onChanged?.call(text);
           cancelTimer();
           return;
         }
@@ -150,6 +151,7 @@ class _AsyncTextFormFieldState extends State<AsyncTextFormField> {
             isValidating = false;
             validationMessage = null;
           });
+          widget.onChanged?.call(text);
           cancelTimer();
           return;
         }
@@ -166,8 +168,8 @@ class _AsyncTextFormFieldState extends State<AsyncTextFormField> {
             isValidating = false;
             validationMessage = msg;
           });
+          widget.onChanged?.call(text);
         });
-        widget.onChanged?.call(text);
       },
       controller: widget.controller,
       decoration: decoration,

--- a/lib/async_textformfield.dart
+++ b/lib/async_textformfield.dart
@@ -1,100 +1,215 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class AsyncTextFormField extends StatefulWidget {
-  final Future<bool> Function(String) validator;
-  final Duration validationDebounce;
-  final TextEditingController controller;
-  final String hintText;
-  final String isValidatingMessage;
-  final String valueIsEmptyMessage;
-  final String valueIsInvalidMessage;
+  final Future<String?> Function(String)? validator;
+  final Duration? validationDebounce;
+  final TextEditingController? controller;
 
-  const AsyncTextFormField(
-      {Key? key,
-      required this.validator,
-      required this.validationDebounce,
-      required this.controller,
-      this.isValidatingMessage = "please wait for the validation to complete",
-      this.valueIsEmptyMessage = 'please enter a value',
-      this.valueIsInvalidMessage = 'please enter a valid value',
-      this.hintText = ''})
-      : super(key: key);
+  final String? initialValue;
+  final FocusNode? focusNode;
+  final TextInputType? keyboardType;
+  final TextCapitalization textCapitalization;
+  final TextInputAction? textInputAction;
+  final TextStyle? style;
+  final StrutStyle? strutStyle;
+  final TextDirection? textDirection;
+  final TextAlign textAlign;
+  final TextAlignVertical? textAlignVertical;
+  final bool autofocus;
+  final bool readOnly;
+  final ToolbarOptions? toolbarOptions;
+  final bool? showCursor;
+  final String obscuringCharacter;
+  final bool obscureText;
+  final bool autocorrect;
+  final SmartDashesType? smartDashesType;
+  final SmartQuotesType? smartQuotesType;
+  final bool enableSuggestions;
+  final MaxLengthEnforcement? maxLengthEnforcement;
+  final int? maxLines;
+  final int? minLines;
+  final bool expands;
+  final int? maxLength;
+  final InputDecoration? decoration;
+  final ValueChanged<String>? onChanged;
+  final GestureTapCallback? onTap;
+  final VoidCallback? onEditingComplete;
+  final ValueChanged<String>? onFieldSubmitted;
+  final FormFieldSetter<String>? onSaved;
+  final List<TextInputFormatter>? inputFormatters;
+  final bool? enabled;
+  final double cursorWidth;
+  final double? cursorHeight;
+  final Radius? cursorRadius;
+  final Color? cursorColor;
+  final Brightness? keyboardAppearance;
+  final EdgeInsets scrollPadding;
+  final bool enableInteractiveSelection;
+  final TextSelectionControls? selectionControls;
+  final InputCounterWidgetBuilder? buildCounter;
+  final ScrollPhysics? scrollPhysics;
+  final Iterable<String>? autofillHints;
+  final AutovalidateMode? autovalidateMode;
+
+  const AsyncTextFormField({
+    Key? key,
+    this.validator,
+    this.validationDebounce,
+    this.controller,
+    this.decoration,
+    this.onChanged,
+    this.onTap,
+    this.onEditingComplete,
+    this.onFieldSubmitted,
+    this.onSaved,
+    this.inputFormatters,
+    this.enabled,
+    this.cursorHeight,
+    this.cursorRadius,
+    this.cursorColor,
+    this.keyboardAppearance,
+    this.selectionControls,
+    this.buildCounter,
+    this.scrollPhysics,
+    this.autofillHints,
+    this.autovalidateMode = AutovalidateMode.onUserInteraction,
+    this.initialValue,
+    this.focusNode,
+    this.keyboardType,
+    this.textInputAction,
+    this.style,
+    this.strutStyle,
+    this.textDirection,
+    this.textAlignVertical,
+    this.toolbarOptions,
+    this.showCursor,
+    this.smartDashesType,
+    this.smartQuotesType,
+    this.maxLengthEnforcement,
+    this.minLines,
+    this.maxLength,
+    this.textCapitalization = TextCapitalization.none,
+    this.scrollPadding = const EdgeInsets.all(20.0),
+    this.textAlign = TextAlign.start,
+    this.autofocus = false,
+    this.readOnly = false,
+    this.obscuringCharacter = '•',
+    this.obscureText = false,
+    this.autocorrect = true,
+    this.enableSuggestions = true,
+    this.maxLines = 1,
+    this.expands = false,
+    this.cursorWidth = 2.0,
+    this.enableInteractiveSelection = true,
+  }) : super(key: key);
 
   @override
   _AsyncTextFormFieldState createState() => _AsyncTextFormFieldState();
 }
 
 class _AsyncTextFormFieldState extends State<AsyncTextFormField> {
-  Timer? _debounce;
-  var isValidating = false;
-  var isValid = false;
-  var isDirty = false;
-  var isWaiting = false;
+  Timer? debounce;
+  String? validationMessage;
+  bool isValidating = false;
+  bool isValid = false;
+  bool isDirty = false;
+  bool isWaiting = false;
+
   @override
   Widget build(BuildContext context) {
+    final decoration = widget.decoration?.copyWith(suffix: SizedBox(height: 20, width: 20, child: _getSuffixIcon())) ??
+        InputDecoration(suffix: SizedBox(height: 20, width: 20, child: _getSuffixIcon()));
     return TextFormField(
-      autovalidateMode: AutovalidateMode.onUserInteraction,
-      validator: (value) {
-        if (isValidating) {
-          return widget.isValidatingMessage;
-        }
-        if (value?.isEmpty ?? false) {
-          return widget.valueIsEmptyMessage;
-        }
-        if (!isWaiting && !isValid) {
-          return widget.valueIsInvalidMessage;
-        }
-        return null;
-      },
+      validator: (value) => validationMessage,
       onChanged: (text) async {
-        isDirty = true;
+        setState(() => isDirty = true);
         if (text.isEmpty) {
+          final msg = await widget.validator?.call(text);
           setState(() {
-            isValid = false;
-            print('is empty');
+            isValid = msg == null;
+            isValidating = false;
+            validationMessage = msg;
           });
           cancelTimer();
           return;
         }
-        isWaiting = true;
+        setState(() => isWaiting = true);
         cancelTimer();
-        _debounce = Timer(widget.validationDebounce, () async {
-          isWaiting = false;
-          isValid = await validate(text);
-          print(isValid);
-          setState(() {});
-          isValidating = false;
+        debounce = Timer(widget.validationDebounce ?? Duration(milliseconds: 500), () async {
+          setState(() {
+            isWaiting = false;
+            isValidating = true;
+          });
+          final msg = await widget.validator?.call(text);
+          setState(() {
+            isValid = msg == null;
+            isValidating = false;
+            validationMessage = msg;
+          });
         });
+        widget.onChanged?.call(text);
       },
-      textAlign: TextAlign.start,
       controller: widget.controller,
-      maxLines: 1,
-      textInputAction: TextInputAction.next,
-      decoration: InputDecoration(suffix: SizedBox(height: 20, width: 20, child: _getSuffixIcon()), hintText: widget.hintText),
+      decoration: decoration,
+      onTap: widget.onTap,
+      onEditingComplete: widget.onEditingComplete,
+      onFieldSubmitted: widget.onFieldSubmitted,
+      onSaved: widget.onSaved,
+      inputFormatters: widget.inputFormatters,
+      enabled: widget.enabled,
+      cursorHeight: widget.cursorHeight,
+      cursorRadius: widget.cursorRadius,
+      cursorColor: widget.cursorColor,
+      keyboardAppearance: widget.keyboardAppearance,
+      selectionControls: widget.selectionControls,
+      buildCounter: widget.buildCounter,
+      scrollPhysics: widget.scrollPhysics,
+      autofillHints: widget.autofillHints,
+      autovalidateMode: widget.autovalidateMode,
+      initialValue: widget.initialValue,
+      focusNode: widget.focusNode,
+      keyboardType: widget.keyboardType,
+      textInputAction: widget.textInputAction,
+      style: widget.style,
+      strutStyle: widget.strutStyle,
+      textDirection: widget.textDirection,
+      textAlignVertical: widget.textAlignVertical,
+      toolbarOptions: widget.toolbarOptions,
+      showCursor: widget.showCursor,
+      smartDashesType: widget.smartDashesType,
+      smartQuotesType: widget.smartQuotesType,
+      maxLengthEnforcement: widget.maxLengthEnforcement,
+      minLines: widget.minLines,
+      maxLength: widget.maxLength,
+      textCapitalization: widget.textCapitalization,
+      scrollPadding: widget.scrollPadding,
+      textAlign: widget.textAlign,
+      autofocus: widget.autofocus,
+      readOnly: widget.readOnly,
+      obscuringCharacter: widget.obscuringCharacter,
+      obscureText: widget.obscureText,
+      autocorrect: widget.autocorrect,
+      enableSuggestions: widget.enableSuggestions,
+      maxLines: widget.maxLines,
+      expands: widget.expands,
+      cursorWidth: widget.cursorWidth,
+      enableInteractiveSelection: widget.enableInteractiveSelection,
     );
   }
 
   @override
   void dispose() {
-    _debounce?.cancel();
+    debounce?.cancel();
     super.dispose();
   }
 
   void cancelTimer() {
-    if (_debounce?.isActive ?? false) {
-      _debounce?.cancel();
+    if (debounce?.isActive ?? false) {
+      debounce?.cancel();
     }
-  }
-
-  Future<bool> validate(String text) async {
-    setState(() {
-      isValidating = true;
-    });
-    final isValid = await widget.validator(text);
-    isValidating = false;
-    return isValid;
   }
 
   Widget _getSuffixIcon() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: async_textformfield
 description: A text form field with an async validator
-version: 2.0.1+3
+version: 2.0.2
 homepage: https://github.com/snippetkid/async_textformfield
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: async_textformfield
 description: A text form field with an async validator
-version: 2.0.0+3
+version: 2.0.1+3
 homepage: https://github.com/snippetkid/async_textformfield
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: async_textformfield
 description: A text form field with an async validator
-version: 2.0.2
+version: 2.0.3
 homepage: https://github.com/snippetkid/async_textformfield
 
 environment:


### PR DESCRIPTION
Use constructor compatible with Flutter Material Design TextFormField to keep things consistent and simplier. Everyone is free to wrap this Widget with another one with limited number of arguments for use in an application. Just like with TextFormField.